### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ BugReports: https://github.com/mlysy/MADPop/issues
 License: GPL-3
 Depends:
     R (>= 3.4.0),
-    rstan (>= 2.18.1)
+    rstan (>= 2.26.0)
 Imports:
     methods,
     Rcpp (>= 0.12.0),
@@ -42,8 +42,8 @@ LinkingTo:
     BH (>= 1.66.0),
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0),
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0),
     RcppParallel (>= 5.0.1)
 VignetteBuilder:
     knitr

--- a/inst/stan/DirichletMultinomial.stan
+++ b/inst/stan/DirichletMultinomial.stan
@@ -15,7 +15,7 @@
 functions {
   // unnormalized dirichlet-multinomial distribution
   // (for likelihood only)
-  real dirichlet_multinomial_lpmf(int[] x, vector eta) {
+  real dirichlet_multinomial_lpmf(array[] int x, vector eta) {
     real ans;
     ans = 0.0;
     for(ii in 1:num_elements(x)) {
@@ -25,8 +25,8 @@ functions {
   }
   // same thing but vectorized, i.e. accepts matrix X
   // current bug prevents overloading...
-  real Dirichlet_Multinomial_lpmf(int[,] X, vector eta) {
-    int D[2];
+  real Dirichlet_Multinomial_lpmf(array[,] int X, vector eta) {
+    array[2] int D;
     real ans;
     real seta;
     real slgeta;
@@ -53,10 +53,10 @@ functions {
 data {
   int<lower=1> nG; // number of observed genotype categories
   int<lower=1> nL; // number of lakes
-  int<lower=0> X[nL,nG]; // vector of counts for each lake
+  array[nL,nG] int<lower=0> X; // vector of counts for each lake
   //real<lower=0> eta; // hyper prior precision parameter
   int<lower=0,upper=nL> nLrho; // number of lakes for which to generate samples from rho
-  int<lower=1,upper=nL> iLrho[nLrho]; // indices of these lakes
+  array[nLrho] int<lower=1,upper=nL> iLrho; // indices of these lakes
 }
 
 parameters {
@@ -76,7 +76,7 @@ model {
 
 generated quantities {
   // individual lake multinomial parameters
-  simplex[nG] rho[nLrho];
+  array[nLrho] simplex[nG] rho;
   if(nLrho > 0) {
     for(ii in 1:nLrho) {
       rho[ii] = dirichlet_rng(to_vector(X[iLrho[ii]]) + eta * alpha);

--- a/inst/stan/devel/HardyWeinberg.stan
+++ b/inst/stan/devel/HardyWeinberg.stan
@@ -4,16 +4,16 @@
 data {
   int<lower=1> nG; // number of observed  genotype categories
   int<lower=1> nH; // number of inherited genotype categories
-  int<lower=0> Xg[nG]; // number of observations for each of the observed genotype categories
+  array[nG] int<lower=0> Xg; // number of observations for each of the observed genotype categories
   // inheritance information
   // for each observed genotype category, each (unordered) combination of inherited genotypes
   // which could make up the observation.  For two locations, there are at most 6 combinations.
-  int<lower=0,upper=nH> Hg[2,6,nG];
-  int<lower=0,upper=6> nHg[nG]; // number of inheritance combinations for each observed genotype category.
+  array[2,6,nG] int<lower=0,upper=nH> Hg;
+  array[nG] int<lower=0,upper=6> nHg; // number of inheritance combinations for each observed genotype category.
 }
 
 transformed data {
-  int ordCount[nG,6]; // how many times to count the order of each inheritance pattern (once or twice)
+  array[nG,6] int ordCount; // how many times to count the order of each inheritance pattern (once or twice)
   for(ii in 1:(nG-1)) {
     for(jj in 1:nHg[ii]) {
       if(Hg[1,jj,ii] == Hg[2,jj,ii]) {

--- a/inst/stan/devel/HardyWeinbergHier.stan
+++ b/inst/stan/devel/HardyWeinbergHier.stan
@@ -5,19 +5,19 @@ data {
   int<lower=1> nL; // number of lakes
   int<lower=1> nG; // number of observed  genotype categories (total)
   int<lower=1> nH; // number of inherited genotype categories (total)
-  int<lower=0> Xg[nL,nG]; // number of observations for each of the observed genotype categories per lake
+  array[nL,nG] int<lower=0> Xg; // number of observations for each of the observed genotype categories per lake
   // inheritance information
   // for each observed genotype category, each (unordered) combination of inherited genotypes
   // which could make up the observation.  For two locations, there are at most 6 combinations.
-  int<lower=0,upper=nH> Hg[2,6,nG];
-  int<lower=0,upper=6> nHg[nG]; // number of inheritance combinations for each observed genotype category.
+  array[2,6,nG] int<lower=0,upper=nH> Hg;
+  array[nG] int<lower=0,upper=6> nHg; // number of inheritance combinations for each observed genotype category.
 //  real mu0; // prior parameters on eta0
 //  real<lower=0> sigma0;
   real<lower=0> eta0; // scale parameter for prior
 }
 
 transformed data {
-  int ordCount[nG,6]; // how many times to count the order of each inheritance pattern (once or twice)
+  array[nG,6] int ordCount; // how many times to count the order of each inheritance pattern (once or twice)
   for(ii in 1:(nG-1)) {
     for(jj in 1:nHg[ii]) {
       if(Hg[1,jj,ii] == Hg[2,jj,ii]) {
@@ -30,13 +30,13 @@ transformed data {
 }
 
 parameters {
-  simplex[nH] rho[nL]; // probability of inheriting each of the elements in H
+  array[nL] simplex[nH] rho; // probability of inheriting each of the elements in H
   simplex[nH] eta; // hyperparameters
 //  real<lower=0> eta0; // scale multiple for prior
 }
 
 transformed parameters {
-  simplex[nG] theta[nL]; // probability of each of the observed genotypes in each lake
+  array[nL] simplex[nG] theta; // probability of each of the observed genotypes in each lake
   for(kk in 1:nL) {
     theta[kk,nG] = 1;
     for(ii in 1:(nG-1)) {


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
