### PR TITLE
Rename dirichlet_multinomial for Stan clash

### DIFF
--- a/inst/stan/DirichletMultinomial.stan
+++ b/inst/stan/DirichletMultinomial.stan
@@ -15,7 +15,7 @@
 functions {
   // unnormalized dirichlet-multinomial distribution
   // (for likelihood only)
-  real dirichlet_multinomial_lpmf(array[] int x, vector eta) {
+  real dirichlet_multinomial2_lpmf(array[] int x, vector eta) {
     real ans;
     ans = 0.0;
     for(ii in 1:num_elements(x)) {

--- a/tests/dontrun/test.R
+++ b/tests/dontrun/test.R
@@ -5,7 +5,7 @@ DM.mod <- stanc(model_code = "
 functions {
   // unnormalized dirichlet-multinomial distribution
   // (for likelihood only)
-  real dirichlet_multinomial_lpmf(int[] x, vector eta) {
+  real dirichlet_multinomial2_lpmf(int[] x, vector eta) {
     real ans;
     ans = 0.0;
     for(ii in 1:num_elements(x)) {
@@ -92,12 +92,12 @@ for(ii in 1:nL) {
 # parameters
 Eta <- replicate(10, rexp(nG, .1))
 
-dirichlet_multinomial_lpmf(x = X[1,], eta = eta)
+dirichlet_multinomial2_lpmf(x = X[1,], eta = eta)
 Dirichlet_Multinomial_lpdf(X = X[1,,drop=FALSE], eta = eta)
 
 # loglikelihood, single lake
 ll1 <- apply(Eta, 2, function(et) {
-  dirichlet_multinomial_lpmf(x = X[1,], eta = et)
+  dirichlet_multinomial2_lpmf(x = X[1,], eta = et)
 })
 ll2 <- apply(Eta, 2, function(et) {
   ddirmulti(x = X[1,], alpha = et, log = TRUE)


### PR DESCRIPTION
There was a `dirichlet_multinomial` distribution added in Stan 2.34, which will cause an installation error with your package under the next version of `rstan`.

This just renames your package's definition to `dirichlet_multinomial2` so that your package is compatible with both current and future `rstan`